### PR TITLE
Fix label methods

### DIFF
--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -19,7 +19,7 @@ module.exports = class Labels extends Diffable {
   }
 
   find () {
-    return this.github.issues.getLabels(this.wrapAttrs({})).then(res => res.data)
+    return this.github.issues.listLabelsForRepo(this.wrapAttrs({})).then(res => res.data)
   }
 
   comparator (existing, attrs) {

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -31,7 +31,7 @@ module.exports = class Labels extends Diffable {
   }
 
   update (existing, attrs) {
-    //attrs.new_name = attrs.new_name || attrs.name
+    attrs.current_name = attrs.current_name || attrs.name
     return this.github.issues.updateLabel(this.wrapAttrs(attrs))
   }
 

--- a/lib/plugins/labels.js
+++ b/lib/plugins/labels.js
@@ -31,7 +31,7 @@ module.exports = class Labels extends Diffable {
   }
 
   update (existing, attrs) {
-    attrs.oldname = attrs.oldname || attrs.name
+    //attrs.new_name = attrs.new_name || attrs.name
     return this.github.issues.updateLabel(this.wrapAttrs(attrs))
   }
 


### PR DESCRIPTION
The current octokit has renamed two label-related methods:

- getLabels has been renamed to called listLabelsForRepo
- issues.update.label has had two argument changes:
    - oldname argument has been renamed name
    - name is now renamed current_name

This PR addresses both issues, which allows Probot-settings to set up labels once again.